### PR TITLE
use relative url for non-root deployment

### DIFF
--- a/src/main/resources/static/Scripts/app.js
+++ b/src/main/resources/static/Scripts/app.js
@@ -9,9 +9,9 @@ angular.module('todoApp', ['ngRoute'])
     .config(['$routeProvider',  function ($routeProvider) {
         $routeProvider.when('/Home', {
             controller: 'homeCtrl',
-            templateUrl: '/Views/Home.html',
+            templateUrl: 'Views/Home.html',
         }).when('/TodoList', {
             controller: 'todoListCtrl',
-            templateUrl: '/Views/TodoList.html',
+            templateUrl: 'Views/TodoList.html',
         }).otherwise({redirectTo: '/Home'});
     }]);

--- a/src/main/resources/static/Scripts/todoListSvc.js
+++ b/src/main/resources/static/Scripts/todoListSvc.js
@@ -9,21 +9,21 @@ angular.module('todoApp')
     .factory('todoListSvc', ['$http', function ($http) {
         return {
             getItems: function () {
-                return $http.get('/api/todolist');
+                return $http.get('api/todolist');
             },
             getItem: function (id) {
-                return $http.get('/api/todolist/' + id);
+                return $http.get('api/todolist/' + id);
             },
             postItem: function (item) {
-                return $http.post('/api/todolist/', item);
+                return $http.post('api/todolist/', item);
             },
             putItem: function (item) {
-                return $http.put('/api/todolist/', item);
+                return $http.put('api/todolist/', item);
             },
             deleteItem: function (id) {
                 return $http({
                     method: 'DELETE',
-                    url: '/api/todolist/' + id
+                    url: 'api/todolist/' + id
                 });
             }
         };


### PR DESCRIPTION
Previously, if deployed to non-root folder, e.g. `localhost:8000/todoapp/`, the template url was wrong, e.g. `localhost:8000/Views/Home.html`. 
Same with url for api calls.
Should use relative path.