### PR TITLE
use openjdk instead of deprecated java image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java
+FROM openjdk
 VOLUME /tmp
 ADD target/*.jar /app.jar
 ENTRYPOINT [ "java", "-jar", "/app.jar", "--server.port=80" ]


### PR DESCRIPTION
related issue: #42 

ref: https://hub.docker.com/_/java/
> DEPRECATED
This image is officially deprecated in favor of the openjdk image, and will receive no further updates after 2016-12-31 (Dec 31, 2016). Please adjust your usage accordingly.
The image has been OpenJDK-specific since it was first introduced, and as of 2016-08-10 we also have an ibmjava image, which made it even more clear that each repository should represent one upstream instead of one language stack or community, so this rename reflects that clarity appropriately.