### PR TITLE
Fix hyperlink on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This TodoList app is an Azure Java application. It provides end-to-end CRUD oper
 * [Create Azure Cosmos DB documentDB](#create-azure-cosmos-db-documentdb)
 * [Configuration](#configuration)
 * [Run it](#run-it)
-* [Contribution](#contribution)
+* [Contribution](#contributing)
 * Add new features
     * [Add AAD](https://github.com/Microsoft/todo-app-java-on-azure/tree/aad-start)
     * [Add KeyVault](https://github.com/Microsoft/todo-app-java-on-azure/tree/keyvault-secrets)


### PR DESCRIPTION
The issue is caused because of different names used in bullet list and header. It can also be fixed by renaming one of them.